### PR TITLE
chore: add localizable consent text to get ready view

### DIFF
--- a/Sources/FaceLiveness/Resources/Base.lproj/Localizable.strings
+++ b/Sources/FaceLiveness/Resources/Base.lproj/Localizable.strings
@@ -17,6 +17,7 @@
 "amplify_ui_liveness_get_ready_lighting" = "Move to a well-lit place that is not in direct sunlight.";
 "amplify_ui_liveness_get_ready_fit_face" = "When an oval appears, fill the oval with your face within 7 seconds.";
 "amplify_ui_liveness_get_ready_begin_check" = "Begin Check";
+"amplify_ui_liveness_get_ready_legal_consent" = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
 
 "amplify_ui_liveness_challenge_recording_indicator_label" = "REC";
 "amplify_ui_liveness_challenge_instruction_hold_face_during_countdown" = "Hold face position during countdown.";

--- a/Sources/FaceLiveness/Utilities/LocalizedStringKey+Liveness.swift
+++ b/Sources/FaceLiveness/Utilities/LocalizedStringKey+Liveness.swift
@@ -68,6 +68,10 @@ extension LocalizedStringKey {
         "amplify_ui_liveness_get_ready_begin_check"
     )
 
+    static let get_ready_legal_consent = LocalizedStringKey(
+        "amplify_ui_liveness_get_ready_legal_consent"
+    )
+
     /// en = "REC"
     static let challenge_recording_indicator_label = LocalizedStringKey(
         "amplify_ui_liveness_challenge_recording_indicator_label"
@@ -147,5 +151,4 @@ extension LocalizedStringKey {
     static let close_button_a11y = LocalizedStringKey(
         "amplify_ui_liveness_close_button_a11y"
     )
-
 }

--- a/Sources/FaceLiveness/Views/GetReadyPage/GetReadyPageView.swift
+++ b/Sources/FaceLiveness/Views/GetReadyPage/GetReadyPageView.swift
@@ -48,6 +48,12 @@ struct GetReadyPageView: View {
                         .padding(.bottom)
 
                     steps()
+                        .padding(.bottom)
+
+                    Text(.get_ready_legal_consent, bundle: .module)
+                        .foregroundColor(.init(UIColor.secondaryLabel))
+                        .font(.system(size: 11))
+                        .frame(alignment: .leading)
                 }
                 .padding()
             }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds localizable legal consent text to get ready view.

| Light Mode  | Dark Mode |
| ------------- | ------------- |
| <img width="483" alt="lorem_ipsum_consent_text_example" src="https://user-images.githubusercontent.com/52051793/231017047-5999e9a8-9c16-4a30-9baf-3d49f0cc3125.png">  | <img width="480" alt="lorem_ipsum_consent_text_example_dark_mode" src="https://user-images.githubusercontent.com/52051793/231017130-91a4a64f-2cc8-40a1-a619-6e03421c74d4.png">  |

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
