### PR TITLE
fix: pass provided credentialsprovider to session

### DIFF
--- a/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionView.swift
+++ b/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionView.swift
@@ -39,6 +39,7 @@ public struct FaceLivenessDetectorView: View {
         self.sessionTask = Task {
             let session = try await AWSPredictionsPlugin.startFaceLivenessSession(
                 withID: sessionID,
+                credentialsProvider: credentialsProvider,
                 region: region,
                 options: .init(),
                 completion: map(detectionCompletion: onCompletion)

--- a/Tests/FaceLivenessTests/CredentialsProviderTestCase.swift
+++ b/Tests/FaceLivenessTests/CredentialsProviderTestCase.swift
@@ -1,0 +1,115 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+import SwiftUI
+import AWSPluginsCore
+@testable import FaceLiveness
+@testable import AWSPredictionsPlugin
+@_spi(PredictionsFaceLiveness) import AWSPredictionsPlugin
+
+@MainActor
+final class CredentialsProviderTestCase: XCTestCase {
+    var videoChunker: VideoChunker!
+    var viewModel: FaceLivenessDetectionViewModel!
+    var faceDetector: MockFaceDetector!
+    var livenessService: MockLivenessService!
+
+    override func setUp() {
+        faceDetector = MockFaceDetector()
+        livenessService = MockLivenessService()
+        let videoChunker = VideoChunker(
+            assetWriter: LivenessAVAssetWriter(),
+            assetWriterDelegate: VideoChunker.AssetWriterDelegate(),
+            assetWriterInput: LivenessAVAssetWriterInput()
+        )
+        let captureSession = LivenessCaptureSession(
+            captureDevice: .init(avCaptureDevice: nil),
+            outputDelegate: OutputSampleBufferCapturer(
+                faceDetector: faceDetector,
+                videoChunker: videoChunker
+            )
+        )
+
+        let viewModel = FaceLivenessDetectionViewModel(
+            faceDetector: faceDetector,
+            faceInOvalMatching: .init(instructor: .init()),
+            captureSession: captureSession,
+            videoChunker: videoChunker,
+            closeButtonAction: {},
+            sessionID: UUID().uuidString
+        )
+
+        self.videoChunker = videoChunker
+        self.viewModel = viewModel
+    }
+
+    /// Given: A `FaceLivenessDetectorView`
+    /// When: The callsite provides an `AWSCredentialsProvider` conforming type that provides
+    /// an `AWSCredentials` conforming type
+    /// Then: The provided `accessKeyId` and `secretAccessKey` should
+    /// match that of credentials used by the underlying `SigV4Signer`. **And** the
+    /// sessionToken should be `nil`
+    func testUsesProvidedCredentialsProvider() async throws {
+        let accessKey = "AKIAIOSFODNN7EXAMPLE"
+        let secretKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        let credentialsProvider = MockCredentialsProvider {
+            MockAWSCredentials(accessKeyId: accessKey, secretAccessKey: secretKey)
+        }
+
+        let liveness = FaceLivenessDetectorView(
+            sessionID: UUID().uuidString,
+            credentialsProvider: credentialsProvider,
+            region: "us-east-1",
+            isPresented: .constant(true),
+            onCompletion: { _ in }
+        )
+
+        let session = try await liveness.sessionTask.value
+        let credential = session.signer.credential
+
+        XCTAssertEqual(accessKey, credential.accessKey)
+        XCTAssertEqual(secretKey, credential.secretKey)
+        XCTAssertNil(credential.sessionToken)
+    }
+
+
+    /// Given: A `FaceLivenessDetectorView`
+    /// When: The callsite provides an `AWSCredentialsProvider` conforming type that provides
+    /// an `AWSTemporaryCredentials` conforming type
+    /// Then: The provided `accessKeyId`, `secretAccessKey`, **and** `sessionToken` should
+    /// match that of credentials used by the underlying `SigV4Signer`
+    func testUsesProvidedCredentialsProvider_temporaryCredentials() async throws {
+        let accessKey = "AKIAIOSFODNN7EXAMPLE"
+        let secretKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        let sessionToken = "MOCK_SESSION_TOKEN"
+
+        let credentialsProvider = MockCredentialsProvider {
+            MockAWSTemporaryCredentials(
+                sessionToken: sessionToken,
+                expiration: .distantFuture,
+                accessKeyId: accessKey,
+                secretAccessKey: secretKey
+            )
+        }
+
+        let liveness = FaceLivenessDetectorView(
+            sessionID: UUID().uuidString,
+            credentialsProvider: credentialsProvider,
+            region: "us-east-1",
+            isPresented: .constant(true),
+            onCompletion: { _ in }
+        )
+
+        let session = try await liveness.sessionTask.value
+        let credential = session.signer.credential
+
+        XCTAssertEqual(accessKey, credential.accessKey)
+        XCTAssertEqual(secretKey, credential.secretKey)
+        XCTAssertEqual(sessionToken, credential.sessionToken)
+    }
+}

--- a/Tests/FaceLivenessTests/MockAWSCredentials.swift
+++ b/Tests/FaceLivenessTests/MockAWSCredentials.swift
@@ -1,0 +1,14 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import AWSPluginsCore
+
+struct MockAWSCredentials: AWSCredentials {
+    var accessKeyId: String
+    var secretAccessKey: String
+}

--- a/Tests/FaceLivenessTests/MockAWSTemporaryCredentials.swift
+++ b/Tests/FaceLivenessTests/MockAWSTemporaryCredentials.swift
@@ -1,0 +1,16 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import AWSPluginsCore
+
+struct MockAWSTemporaryCredentials: AWSTemporaryCredentials {
+    var sessionToken: String
+    var expiration: Date
+    var accessKeyId: String
+    var secretAccessKey: String
+}

--- a/Tests/FaceLivenessTests/MockCredentialsProvider.swift
+++ b/Tests/FaceLivenessTests/MockCredentialsProvider.swift
@@ -1,0 +1,17 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import AWSPluginsCore
+
+struct MockCredentialsProvider: AWSCredentialsProvider {
+    let credentials: () -> AWSCredentials
+
+    func fetchAWSCredentials() async throws -> AWSCredentials {
+        credentials()
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Passes a caller provided credentials provider down to the session creation.

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
