### PR TITLE
fix: typo in localizable.strings

### DIFF
--- a/Sources/FaceLiveness/Resources/Base.lproj/Localizable.strings
+++ b/Sources/FaceLiveness/Resources/Base.lproj/Localizable.strings
@@ -21,7 +21,7 @@
 "amplify_ui_liveness_challenge_recording_indicator_label" = "REC";
 "amplify_ui_liveness_challenge_instruction_hold_face_during_countdown" = "Hold face position during countdown.";
 "amplify_ui_liveness_challenge_instruction_hold_face_during_freshness" = "Hold face in oval for colored lights.";
-"amplify_ui_liveness_challenge_instruction_move_face_bqck" = "Move back";
+"amplify_ui_liveness_challenge_instruction_move_face_back" = "Move back";
 "amplify_ui_liveness_challenge_instruction_move_face_closer" = "Move closer";
 "amplify_ui_liveness_challenge_instruction_move_face_in_front_of_camera" = "Move face in front of camera";
 "amplify_ui_liveness_challenge_instruction_multiple_faces_detected" = "Ensure only one face is in front of camera";


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes typo in Localizable.strings that presented the key rather than the value on screen.

*Check points: (check or cross out if not relevant)*

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
