### PR TITLE
fix: send client close frame

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/aws-amplify/amplify-swift",
       "state" : {
-        "revision" : "4241439bae1662134f0a73bd87c84f7384ffabb6",
-        "version" : "2.11.0"
+        "branch" : "main",
+        "revision" : "3c947fc1bc03be03317b99833cc99dcc2dff310d"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/aws-amplify/amplify-swift-utils-notifications.git",
       "state" : {
-        "revision" : "d4fd3c17e8d40efc821f448d3d6cff75b8f3b0dd",
-        "version" : "1.0.0"
+        "revision" : "f970384ad1035732f99259255cd2f97564807e41",
+        "version" : "1.1.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/aws-amplify/amplify-swift",
       "state" : {
-        "branch" : "main",
-        "revision" : "3c947fc1bc03be03317b99833cc99dcc2dff310d"
+        "revision" : "bb69fc1febc23dfc539531ce7dd3b51cdf97d813",
+        "version" : "2.14.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["FaceLiveness"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/aws-amplify/amplify-swift", branch: "fix/expose-session-closure-liveness")
+        .package(url: "https://github.com/aws-amplify/amplify-swift", branch: "main") //2.14.1
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["FaceLiveness"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/aws-amplify/amplify-swift", from: "2.11.0")
+        .package(url: "https://github.com/aws-amplify/amplify-swift", branch: "fix/expose-session-closure-liveness")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["FaceLiveness"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/aws-amplify/amplify-swift", branch: "main") //2.14.1
+        .package(url: "https://github.com/aws-amplify/amplify-swift", from: "2.14.1")
     ],
     targets: [
         .target(

--- a/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionView.swift
+++ b/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionView.swift
@@ -167,7 +167,6 @@ public struct FaceLivenessDetectorView: View {
             .onReceive(viewModel.$livenessState) { output in
                 switch output.state {
                 case .completed:
-                    viewModel.livenessService.closeSocket(with: .normalClosure)
                     isPresented = false
                     onCompletion(.success(()))
                 case .encounteredUnrecoverableError(let error):

--- a/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionView.swift
+++ b/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionView.swift
@@ -167,9 +167,11 @@ public struct FaceLivenessDetectorView: View {
             .onReceive(viewModel.$livenessState) { output in
                 switch output.state {
                 case .completed:
+                    viewModel.livenessService.closeSocket(with: .normalClosure)
                     isPresented = false
                     onCompletion(.success(()))
                 case .encounteredUnrecoverableError(let error):
+                    viewModel.livenessService.closeSocket(with: .normalClosure)
                     isPresented = false
                     onCompletion(.failure(mapError(error)))
                 default:

--- a/Tests/FaceLivenessTests/MockLivenessService.swift
+++ b/Tests/FaceLivenessTests/MockLivenessService.swift
@@ -20,6 +20,7 @@ class MockLivenessService {
     var onVideoEvent: (LivenessEvent<VideoEvent>, Date) -> Void = { _, _ in }
     var onInitializeLivenessStream: (String, String) -> Void = { _, _ in }
     var onServiceException: (FaceLivenessSessionError) -> Void = { _ in }
+    var onCloseSocket: (URLSessionWebSocketTask.CloseCode) -> Void = { _ in }
 }
 
 extension MockLivenessService: LivenessService {
@@ -60,5 +61,10 @@ extension MockLivenessService: LivenessService {
         on event: LivenessEventKind.Server
     ) {
         interactions.append(#function)
+    }
+
+    func closeSocket(with code: URLSessionWebSocketTask.CloseCode) {
+        interactions.append(#function)
+        onCloseSocket(code)
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Sends websocket close frame in the case of a client side timeout of face in oval matching.

*Check points: (check or cross out if not relevant)*

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
