### PR TITLE
fix: update no match timeout check from frame count to elapsed time

### DIFF
--- a/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionViewModel+FaceDetectionResultHandler.swift
+++ b/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionViewModel+FaceDetectionResultHandler.swift
@@ -83,14 +83,13 @@ extension FaceLivenessDetectionViewModel: FaceDetectionResultHandler {
         }
     }
 
-    private let noMatchTimeoutInterval: TimeInterval = 7
-
     func handleNoMatch(instruction: Instructor.Instruction, percentage: Double) {
+        let noMatchTimeoutInterval: TimeInterval = 7
         self.livenessState.awaitingFaceMatch(with: instruction, nearnessPercentage: percentage)
         if noMatchStartTime == nil {
             noMatchStartTime = Date()
         }
-        if let elapsedTime = -noMatchStartTime?.timeIntervalSinceNow, elapsedTime >= noMatchTimeoutInterval {
+        if let elapsedTime = noMatchStartTime?.timeIntervalSinceNow, abs(elapsedTime) >= noMatchTimeoutInterval {
             self.livenessState
                 .unrecoverableStateEncountered(.timedOut)
             self.captureSession.stopRunning()

--- a/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionViewModel+FaceDetectionResultHandler.swift
+++ b/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionViewModel+FaceDetectionResultHandler.swift
@@ -84,7 +84,7 @@ extension FaceLivenessDetectionViewModel: FaceDetectionResultHandler {
     }
 
     private let noMatchTimeoutInterval: TimeInterval = 7
-    
+
     func handleNoMatch(instruction: Instructor.Instruction, percentage: Double) {
         self.livenessState.awaitingFaceMatch(with: instruction, nearnessPercentage: percentage)
         if noMatchStartTime == nil {

--- a/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionViewModel.swift
+++ b/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionViewModel.swift
@@ -39,8 +39,8 @@ class FaceLivenessDetectionViewModel: ObservableObject {
     var faceGuideRect: CGRect!
     var initialClientEvent: InitialClientEvent?
     var faceMatchedTimestamp: UInt64?
-    var noMatchCount = 0
-
+    var noMatchStartTime: Date?
+    
     init(
         faceDetector: FaceDetector,
         faceInOvalMatching: FaceInOvalMatching,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Change no match timeout duration check from frames per seconds to elapsed time interval so that timeout is not longer than 7 seconds.

*Check points: (check or cross out if not relevant)*

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [ ] ~PR title conforms to conventional commit style~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
