### PR TITLE
chore: provide more fine-grained websocket close code on errors

### DIFF
--- a/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionView.swift
+++ b/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionView.swift
@@ -170,7 +170,7 @@ public struct FaceLivenessDetectorView: View {
                     isPresented = false
                     onCompletion(.success(()))
                 case .encounteredUnrecoverableError(let error):
-                    viewModel.livenessService.closeSocket(with: mapErrorToCloseCode(error))
+                    viewModel.livenessService.closeSocket(with: error.closeCode)
                     isPresented = false
                     onCompletion(.failure(mapError(error)))
                 default:
@@ -224,32 +224,6 @@ public struct FaceLivenessDetectorView: View {
             break
         }
     }
-    
-    func mapErrorToCloseCode(_ livenessError: LivenessStateMachine.LivenessError) -> URLSessionWebSocketTask.CloseCode {
-        var closeCode: URLSessionWebSocketTask.CloseCode?
-        switch livenessError {
-        case .userCancelled:
-            closeCode = URLSessionWebSocketTask.CloseCode.ovalFitUserClosedSession
-        case .timedOut:
-            closeCode = URLSessionWebSocketTask.CloseCode.ovalFitMatchTimeout
-        case .socketClosed:
-            closeCode = .normalClosure
-        case .missingVideoPermission:
-            closeCode = URLSessionWebSocketTask.CloseCode.missingVideoPermission
-        case .viewResignation:
-            closeCode = URLSessionWebSocketTask.CloseCode.viewClosure
-        case .unknown, .errorWithUnderlyingOSFramework, .couldNotOpenStream:
-            closeCode = URLSessionWebSocketTask.CloseCode.unexpectedRuntimeError
-        default:
-            closeCode = .normalClosure
-        }
-        
-        if let code = closeCode {
-            return code
-        } else {
-            return URLSessionWebSocketTask.CloseCode.normalClosure
-        }
-    }
 }
 
 enum DisplayState {
@@ -288,13 +262,4 @@ private func map(detectionCompletion: @escaping (Result<Void, FaceLivenessDetect
             detectionCompletion(.failure(.unknown))
         }
     }
-}
-
-extension URLSessionWebSocketTask.CloseCode {
-    static let ovalFitMatchTimeout = URLSessionWebSocketTask.CloseCode(rawValue: 5001)
-    static let ovalFitTimeOutNoFaceDetected = URLSessionWebSocketTask.CloseCode(rawValue: 5002)
-    static let ovalFitUserClosedSession = URLSessionWebSocketTask.CloseCode(rawValue: 5003)
-    static let viewClosure = URLSessionWebSocketTask.CloseCode(rawValue: 5004)
-    static let unexpectedRuntimeError = URLSessionWebSocketTask.CloseCode(rawValue: 5005)
-    static let missingVideoPermission = URLSessionWebSocketTask.CloseCode(rawValue: 5006)
 }

--- a/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionView.swift
+++ b/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionView.swift
@@ -184,7 +184,7 @@ public struct FaceLivenessDetectorView: View {
         switch livenessError {
         case .userCancelled:
             return .userCancelled
-        case .faceFitTimedOut, .nofaceFitTimedOut:
+        case .timedOut:
             return .sessionTimedOut
         case .socketClosed:
             return .socketClosed
@@ -230,16 +230,14 @@ public struct FaceLivenessDetectorView: View {
         switch livenessError {
         case .userCancelled:
             closeCode = URLSessionWebSocketTask.CloseCode.ovalFitUserClosedSession
-        case .faceFitTimedOut:
+        case .timedOut:
             closeCode = URLSessionWebSocketTask.CloseCode.ovalFitMatchTimeout
-        case .nofaceFitTimedOut:
-            closeCode = URLSessionWebSocketTask.CloseCode.ovalFitTimeOutNoFaceDetected
         case .socketClosed:
             closeCode = .normalClosure
         case .missingVideoPermission:
             closeCode = URLSessionWebSocketTask.CloseCode.missingVideoPermission
-        case .appResignation:
-            closeCode = URLSessionWebSocketTask.CloseCode.appClosure
+        case .viewResignation:
+            closeCode = URLSessionWebSocketTask.CloseCode.viewClosure
         case .unknown, .errorWithUnderlyingOSFramework, .couldNotOpenStream:
             closeCode = URLSessionWebSocketTask.CloseCode.unexpectedRuntimeError
         default:
@@ -296,7 +294,7 @@ extension URLSessionWebSocketTask.CloseCode {
     static let ovalFitMatchTimeout = URLSessionWebSocketTask.CloseCode(rawValue: 5001)
     static let ovalFitTimeOutNoFaceDetected = URLSessionWebSocketTask.CloseCode(rawValue: 5002)
     static let ovalFitUserClosedSession = URLSessionWebSocketTask.CloseCode(rawValue: 5003)
-    static let appClosure = URLSessionWebSocketTask.CloseCode(rawValue: 5004)
+    static let viewClosure = URLSessionWebSocketTask.CloseCode(rawValue: 5004)
     static let unexpectedRuntimeError = URLSessionWebSocketTask.CloseCode(rawValue: 5005)
     static let missingVideoPermission = URLSessionWebSocketTask.CloseCode(rawValue: 5006)
 }

--- a/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionView.swift
+++ b/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionView.swift
@@ -170,7 +170,8 @@ public struct FaceLivenessDetectorView: View {
                     isPresented = false
                     onCompletion(.success(()))
                 case .encounteredUnrecoverableError(let error):
-                    viewModel.livenessService.closeSocket(with: error.closeCode)
+                    let closeCode = error.webSocketCloseCode ?? .normalClosure
+                    viewModel.livenessService.closeSocket(with: closeCode)
                     isPresented = false
                     onCompletion(.failure(mapError(error)))
                 default:

--- a/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionViewModel+FaceDetectionResultHandler.swift
+++ b/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionViewModel+FaceDetectionResultHandler.swift
@@ -10,6 +10,7 @@ import SwiftUI
 @_spi(PredictionsFaceLiveness) import AWSPredictionsPlugin
 
 fileprivate let initialFaceDistanceThreshold: CGFloat = 0.32
+fileprivate let noFitTimeoutInterval: TimeInterval = 7
 
 extension FaceLivenessDetectionViewModel: FaceDetectionResultHandler {
     func process(newResult: FaceDetectionResult) {
@@ -83,17 +84,26 @@ extension FaceLivenessDetectionViewModel: FaceDetectionResultHandler {
         }
     }
 
-    func handleNoMatch(instruction: Instructor.Instruction, percentage: Double) {
-        let noMatchTimeoutInterval: TimeInterval = 7
+    func handleNoFaceFit(instruction: Instructor.Instruction, percentage: Double) {
         self.livenessState.awaitingFaceMatch(with: instruction, nearnessPercentage: percentage)
-        if noMatchStartTime == nil {
-            noMatchStartTime = Date()
+        if noFitStartTime == nil {
+            noFitStartTime = Date()
         }
-        if let elapsedTime = noMatchStartTime?.timeIntervalSinceNow, abs(elapsedTime) >= noMatchTimeoutInterval {
+        if let elapsedTime = noFitStartTime?.timeIntervalSinceNow, abs(elapsedTime) >= noFitTimeoutInterval {
             self.livenessState
-                .unrecoverableStateEncountered(.timedOut)
+                .unrecoverableStateEncountered(.faceFitTimedOut)
             self.captureSession.stopRunning()
-            return
+        }
+    }
+    
+    func handleNoFaceDetected() {
+        if noFitStartTime == nil {
+            noFitStartTime = Date()
+        }
+        if let elapsedTime = noFitStartTime?.timeIntervalSinceNow, abs(elapsedTime) >= noFitTimeoutInterval {
+            self.livenessState
+                .unrecoverableStateEncountered(.nofaceFitTimedOut)
+            self.captureSession.stopRunning()
         }
     }
 
@@ -109,14 +119,15 @@ extension FaceLivenessDetectionViewModel: FaceDetectionResultHandler {
                 self.livenessViewControllerDelegate?.displayFreshness(colorSequences: colorSequences)
                 let generator = UINotificationFeedbackGenerator()
                 generator.notificationOccurred(.success)
-                self.noMatchStartTime = nil
+                self.noFitStartTime = nil
 
             case .tooClose(_, let percentage),
                     .tooFar(_, let percentage),
                     .tooFarLeft(_, let percentage),
                     .tooFarRight(_, let percentage):
-                self.handleNoMatch(instruction: instruction, percentage: percentage)
-            default: break
+                self.handleNoFaceFit(instruction: instruction, percentage: percentage)
+            case .none:
+                self.handleNoFaceDetected()
             }
         }
     }

--- a/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionViewModel+FaceDetectionResultHandler.swift
+++ b/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionViewModel+FaceDetectionResultHandler.swift
@@ -91,7 +91,7 @@ extension FaceLivenessDetectionViewModel: FaceDetectionResultHandler {
         }
         if let elapsedTime = noFitStartTime?.timeIntervalSinceNow, abs(elapsedTime) >= noFitTimeoutInterval {
             self.livenessState
-                .unrecoverableStateEncountered(.faceFitTimedOut)
+                .unrecoverableStateEncountered(.timedOut)
             self.captureSession.stopRunning()
         }
     }
@@ -102,7 +102,7 @@ extension FaceLivenessDetectionViewModel: FaceDetectionResultHandler {
         }
         if let elapsedTime = noFitStartTime?.timeIntervalSinceNow, abs(elapsedTime) >= noFitTimeoutInterval {
             self.livenessState
-                .unrecoverableStateEncountered(.nofaceFitTimedOut)
+                .unrecoverableStateEncountered(.timedOut)
             self.captureSession.stopRunning()
         }
     }

--- a/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionViewModel.swift
+++ b/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionViewModel.swift
@@ -39,7 +39,7 @@ class FaceLivenessDetectionViewModel: ObservableObject {
     var faceGuideRect: CGRect!
     var initialClientEvent: InitialClientEvent?
     var faceMatchedTimestamp: UInt64?
-    var noMatchStartTime: Date?
+    var noFitStartTime: Date?
     
     init(
         faceDetector: FaceDetector,
@@ -108,7 +108,7 @@ class FaceLivenessDetectionViewModel: ObservableObject {
     @objc func willResignActive(_ notification: Notification) {
         DispatchQueue.main.async {
             self.stopRecording()
-            self.livenessState.unrecoverableStateEncountered(.socketClosed)
+            self.livenessState.unrecoverableStateEncountered(.appResignation)
         }
     }
 

--- a/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionViewModel.swift
+++ b/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionViewModel.swift
@@ -108,7 +108,7 @@ class FaceLivenessDetectionViewModel: ObservableObject {
     @objc func willResignActive(_ notification: Notification) {
         DispatchQueue.main.async {
             self.stopRecording()
-            self.livenessState.unrecoverableStateEncountered(.appResignation)
+            self.livenessState.unrecoverableStateEncountered(.viewResignation)
         }
     }
 

--- a/Sources/FaceLiveness/Views/Liveness/LivenessStateMachine.swift
+++ b/Sources/FaceLiveness/Views/Liveness/LivenessStateMachine.swift
@@ -124,37 +124,19 @@ struct LivenessStateMachine {
 
     struct LivenessError: Error, Equatable {
         let code: UInt8
-
-        static let unknown = LivenessError(code: 0)
-        static let missingVideoPermission = LivenessError(code: 1)
-        static let errorWithUnderlyingOSFramework = LivenessError(code: 2)
-        static let userCancelled = LivenessError(code: 3)
-        static let timedOut = LivenessError(code: 4)
-        static let couldNotOpenStream = LivenessError(code: 5)
-        static let socketClosed = LivenessError(code: 6)
-        static let viewResignation = LivenessError(code: 8)
+        let webSocketCloseCode: URLSessionWebSocketTask.CloseCode?
+        
+        static let unknown = LivenessError(code: 0, webSocketCloseCode: .unexpectedRuntimeError)
+        static let missingVideoPermission = LivenessError(code: 1, webSocketCloseCode: .missingVideoPermission)
+        static let errorWithUnderlyingOSFramework = LivenessError(code: 2, webSocketCloseCode: .unexpectedRuntimeError)
+        static let userCancelled = LivenessError(code: 3, webSocketCloseCode: .ovalFitUserClosedSession)
+        static let timedOut = LivenessError(code: 4, webSocketCloseCode: .ovalFitMatchTimeout)
+        static let couldNotOpenStream = LivenessError(code: 5, webSocketCloseCode: .unexpectedRuntimeError)
+        static let socketClosed = LivenessError(code: 6, webSocketCloseCode: .normalClosure)
+        static let viewResignation = LivenessError(code: 8, webSocketCloseCode: .viewClosure)
 
         static func == (lhs: LivenessError, rhs: LivenessError) -> Bool {
             lhs.code == rhs.code
-        }
-        
-        var closeCode: URLSessionWebSocketTask.CloseCode {
-            switch self {
-            case .userCancelled:
-                return .ovalFitUserClosedSession ?? .normalClosure
-            case .timedOut:
-                return .ovalFitMatchTimeout ?? .normalClosure
-            case .socketClosed:
-                return .normalClosure
-            case .missingVideoPermission:
-                return .missingVideoPermission ?? .normalClosure
-            case .viewResignation:
-                return .viewClosure ?? .normalClosure
-            case .unknown, .errorWithUnderlyingOSFramework, .couldNotOpenStream:
-                return .unexpectedRuntimeError ?? .normalClosure
-            default:
-                return .normalClosure
-            }
         }
     }
 }

--- a/Sources/FaceLiveness/Views/Liveness/LivenessStateMachine.swift
+++ b/Sources/FaceLiveness/Views/Liveness/LivenessStateMachine.swift
@@ -137,5 +137,33 @@ struct LivenessStateMachine {
         static func == (lhs: LivenessError, rhs: LivenessError) -> Bool {
             lhs.code == rhs.code
         }
+        
+        var closeCode: URLSessionWebSocketTask.CloseCode {
+            switch self {
+            case .userCancelled:
+                return .ovalFitUserClosedSession ?? .normalClosure
+            case .timedOut:
+                return .ovalFitMatchTimeout ?? .normalClosure
+            case .socketClosed:
+                return .normalClosure
+            case .missingVideoPermission:
+                return .missingVideoPermission ?? .normalClosure
+            case .viewResignation:
+                return .viewClosure ?? .normalClosure
+            case .unknown, .errorWithUnderlyingOSFramework, .couldNotOpenStream:
+                return .unexpectedRuntimeError ?? .normalClosure
+            default:
+                return .normalClosure
+            }
+        }
     }
+}
+
+extension URLSessionWebSocketTask.CloseCode {
+    static let ovalFitMatchTimeout = URLSessionWebSocketTask.CloseCode(rawValue: 4001)
+    static let ovalFitTimeOutNoFaceDetected = URLSessionWebSocketTask.CloseCode(rawValue: 4002)
+    static let ovalFitUserClosedSession = URLSessionWebSocketTask.CloseCode(rawValue: 4003)
+    static let viewClosure = URLSessionWebSocketTask.CloseCode(rawValue: 4004)
+    static let unexpectedRuntimeError = URLSessionWebSocketTask.CloseCode(rawValue: 4005)
+    static let missingVideoPermission = URLSessionWebSocketTask.CloseCode(rawValue: 4006)
 }

--- a/Sources/FaceLiveness/Views/Liveness/LivenessStateMachine.swift
+++ b/Sources/FaceLiveness/Views/Liveness/LivenessStateMachine.swift
@@ -129,11 +129,10 @@ struct LivenessStateMachine {
         static let missingVideoPermission = LivenessError(code: 1)
         static let errorWithUnderlyingOSFramework = LivenessError(code: 2)
         static let userCancelled = LivenessError(code: 3)
-        static let faceFitTimedOut = LivenessError(code: 4)
+        static let timedOut = LivenessError(code: 4)
         static let couldNotOpenStream = LivenessError(code: 5)
         static let socketClosed = LivenessError(code: 6)
-        static let appResignation = LivenessError(code: 7)
-        static let nofaceFitTimedOut = LivenessError(code: 8)
+        static let viewResignation = LivenessError(code: 8)
 
         static func == (lhs: LivenessError, rhs: LivenessError) -> Bool {
             lhs.code == rhs.code

--- a/Sources/FaceLiveness/Views/Liveness/LivenessStateMachine.swift
+++ b/Sources/FaceLiveness/Views/Liveness/LivenessStateMachine.swift
@@ -129,10 +129,11 @@ struct LivenessStateMachine {
         static let missingVideoPermission = LivenessError(code: 1)
         static let errorWithUnderlyingOSFramework = LivenessError(code: 2)
         static let userCancelled = LivenessError(code: 3)
-        static let timedOut = LivenessError(code: 4)
+        static let faceFitTimedOut = LivenessError(code: 4)
         static let couldNotOpenStream = LivenessError(code: 5)
         static let socketClosed = LivenessError(code: 6)
-        static let invalidFaceMovementDuringCountdown = LivenessError(code: 7)
+        static let appResignation = LivenessError(code: 7)
+        static let nofaceFitTimedOut = LivenessError(code: 8)
 
         static func == (lhs: LivenessError, rhs: LivenessError) -> Bool {
             lhs.code == rhs.code

--- a/Tests/FaceLivenessTests/LivenessTests.swift
+++ b/Tests/FaceLivenessTests/LivenessTests.swift
@@ -140,18 +140,34 @@ final class FaceLivenessDetectionViewModelTestCase: XCTestCase {
     }
     
     /// Given:  A `FaceLivenessDetectionViewModel`
-    /// When: The viewModel handles a no match event over a duration of 7 seconds
+    /// When: The viewModel handles a no fit event over a duration of 7 seconds
     /// Then: The end state is `.encounteredUnrecoverableError(.timedOut)`
-    func testNoMatchTimeoutCheck() async throws {
+    func testNoFitTimeoutCheck() async throws {
         viewModel.livenessService = self.livenessService
-        self.viewModel.handleNoMatch(instruction: .tooFar(nearnessPercentage: 0.2), percentage: 0.2)
+        self.viewModel.handleNoFaceFit(instruction: .tooFar(nearnessPercentage: 0.2), percentage: 0.2)
         
         XCTAssertNotEqual(self.viewModel.livenessState.state, .encounteredUnrecoverableError(.timedOut))
         try await Task.sleep(seconds: 6)
-        self.viewModel.handleNoMatch(instruction: .tooFar(nearnessPercentage: 0.2), percentage: 0.2)
+        self.viewModel.handleNoFaceFit(instruction: .tooFar(nearnessPercentage: 0.2), percentage: 0.2)
         XCTAssertNotEqual(self.viewModel.livenessState.state,  .encounteredUnrecoverableError(.timedOut))
         try await Task.sleep(seconds: 1)
-        self.viewModel.handleNoMatch(instruction: .tooFar(nearnessPercentage: 0.2), percentage: 0.2)
+        self.viewModel.handleNoFaceFit(instruction: .tooFar(nearnessPercentage: 0.2), percentage: 0.2)
+        XCTAssertEqual(self.viewModel.livenessState.state,  .encounteredUnrecoverableError(.timedOut))
+    }
+    
+    /// Given:  A `FaceLivenessDetectionViewModel`
+    /// When: The viewModel handles a no face detected event over a duration of 7 seconds
+    /// Then: The end state is `.encounteredUnrecoverableError(.timedOut)`
+    func testNoFaceDetectedTimeoutCheck() async throws {
+        viewModel.livenessService = self.livenessService
+        self.viewModel.handleNoFaceDetected()
+        
+        XCTAssertNotEqual(self.viewModel.livenessState.state, .encounteredUnrecoverableError(.timedOut))
+        try await Task.sleep(seconds: 6)
+        self.viewModel.handleNoFaceFit(instruction: .tooFar(nearnessPercentage: 0.2), percentage: 0.2)
+        XCTAssertNotEqual(self.viewModel.livenessState.state,  .encounteredUnrecoverableError(.timedOut))
+        try await Task.sleep(seconds: 1)
+        self.viewModel.handleNoFaceDetected()
         XCTAssertEqual(self.viewModel.livenessState.state,  .encounteredUnrecoverableError(.timedOut))
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* update web socket close to include liveness-specific close code
* update timeout logic start the timeout timer when the oval is initially displayed to handle edge case when a face is detected and the oval is displayed and the user moves away immediately

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
