### PR TITLE
fix: update session timed out error to be non-blocking

### DIFF
--- a/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionViewModel+FaceDetectionResultHandler.swift
+++ b/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionViewModel+FaceDetectionResultHandler.swift
@@ -89,11 +89,7 @@ extension FaceLivenessDetectionViewModel: FaceDetectionResultHandler {
             noFitStartTime = Date()
         }
         if let elapsedTime = noFitStartTime?.timeIntervalSinceNow, abs(elapsedTime) >= noFitTimeoutInterval {
-            DispatchQueue.main.async {
-                self.livenessState
-                    .unrecoverableStateEncountered(.timedOut)
-                self.captureSession.stopRunning()
-            }
+            handleSessionTimedOut()
         }
     }
     
@@ -102,11 +98,7 @@ extension FaceLivenessDetectionViewModel: FaceDetectionResultHandler {
             noFitStartTime = Date()
         }
         if let elapsedTime = noFitStartTime?.timeIntervalSinceNow, abs(elapsedTime) >= noFitTimeoutInterval {
-            DispatchQueue.main.async {
-                self.livenessState
-                    .unrecoverableStateEncountered(.timedOut)
-                self.captureSession.stopRunning()
-            }
+            handleSessionTimedOut()
         }
     }
 
@@ -132,6 +124,14 @@ extension FaceLivenessDetectionViewModel: FaceDetectionResultHandler {
             case .none:
                 self.handleNoFaceDetected()
             }
+        }
+    }
+    
+    private func handleSessionTimedOut() {
+        DispatchQueue.main.async {
+            self.livenessState
+                .unrecoverableStateEncountered(.timedOut)
+            self.captureSession.stopRunning()
         }
     }
 }

--- a/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionViewModel+FaceDetectionResultHandler.swift
+++ b/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionViewModel+FaceDetectionResultHandler.swift
@@ -89,9 +89,11 @@ extension FaceLivenessDetectionViewModel: FaceDetectionResultHandler {
             noFitStartTime = Date()
         }
         if let elapsedTime = noFitStartTime?.timeIntervalSinceNow, abs(elapsedTime) >= noFitTimeoutInterval {
-            self.livenessState
-                .unrecoverableStateEncountered(.timedOut)
-            self.captureSession.stopRunning()
+            DispatchQueue.main.async {
+                self.livenessState
+                    .unrecoverableStateEncountered(.timedOut)
+                self.captureSession.stopRunning()
+            }
         }
     }
     
@@ -100,9 +102,11 @@ extension FaceLivenessDetectionViewModel: FaceDetectionResultHandler {
             noFitStartTime = Date()
         }
         if let elapsedTime = noFitStartTime?.timeIntervalSinceNow, abs(elapsedTime) >= noFitTimeoutInterval {
-            self.livenessState
-                .unrecoverableStateEncountered(.timedOut)
-            self.captureSession.stopRunning()
+            DispatchQueue.main.async {
+                self.livenessState
+                    .unrecoverableStateEncountered(.timedOut)
+                self.captureSession.stopRunning()
+            }
         }
     }
 

--- a/Tests/FaceLivenessTests/LivenessTests.swift
+++ b/Tests/FaceLivenessTests/LivenessTests.swift
@@ -152,6 +152,7 @@ final class FaceLivenessDetectionViewModelTestCase: XCTestCase {
         XCTAssertNotEqual(self.viewModel.livenessState.state,  .encounteredUnrecoverableError(.timedOut))
         try await Task.sleep(seconds: 1)
         self.viewModel.handleNoFaceFit(instruction: .tooFar(nearnessPercentage: 0.2), percentage: 0.2)
+        try await Task.sleep(seconds: 1)
         XCTAssertEqual(self.viewModel.livenessState.state,  .encounteredUnrecoverableError(.timedOut))
     }
     
@@ -168,6 +169,7 @@ final class FaceLivenessDetectionViewModelTestCase: XCTestCase {
         XCTAssertNotEqual(self.viewModel.livenessState.state,  .encounteredUnrecoverableError(.timedOut))
         try await Task.sleep(seconds: 1)
         self.viewModel.handleNoFaceDetected()
+        try await Task.sleep(seconds: 1)
         XCTAssertEqual(self.viewModel.livenessState.state,  .encounteredUnrecoverableError(.timedOut))
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-ui-swift-liveness/issues/61
*Description of changes:*
* Dispatch session time out error to be async to unblock component completion handler
*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
