### PR TITLE
fix: duplicate session timeout error messages

### DIFF
--- a/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionViewModel+FaceDetectionResultHandler.swift
+++ b/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionViewModel+FaceDetectionResultHandler.swift
@@ -128,6 +128,7 @@ extension FaceLivenessDetectionViewModel: FaceDetectionResultHandler {
     }
     
     private func handleSessionTimedOut() {
+        noFitStartTime = nil
         DispatchQueue.main.async {
             self.livenessState
                 .unrecoverableStateEncountered(.timedOut)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-ui-swift-liveness/issues/61
*Description of changes:*
* Reset the session timeout time so that duplicate errors are being sent once in error state
*Check points: (check or cross out if not relevant)*

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] If breaking change, documentation/changelog update with migration instructions


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
