### PR TITLE
chore: update missing localization strings for face not prepared reasons

### DIFF
--- a/Sources/FaceLiveness/Resources/Base.lproj/Localizable.strings
+++ b/Sources/FaceLiveness/Resources/Base.lproj/Localizable.strings
@@ -38,3 +38,15 @@
 "amplify_ui_liveness_camera_permission_button_title" = "Change Camera Setting";
 "amplify_ui_liveness_camera_permission_button_header" = "Camera is not accessible";
 "amplify_ui_liveness_camera_permission_button_description" = "You may have to go into settings to grant camera permissions and close the app and retry.";
+
+"amplify_ui_liveness_face_not_prepared_reason_pendingCheck" = "";
+"amplify_ui_liveness_face_not_prepared_reason_not_in_oval" = "Move face to fit in oval";
+"amplify_ui_liveness_face_not_prepared_reason_move_face_closer" = "Move closer";
+"amplify_ui_liveness_face_not_prepared_reason_move_face_right" = "Move face right";
+"amplify_ui_liveness_face_not_prepared_reason_move_face_left" = "Move face left";
+"amplify_ui_liveness_face_not_prepared_reason_move_to_dimmer_area" = "Move to dimmer area";
+"amplify_ui_liveness_face_not_prepared_reason_move_to_brighter_area" = "Move to brighter area";
+"amplify_ui_liveness_face_not_prepared_reason_no_face" = "Move face in front of camera";
+"amplify_ui_liveness_face_not_prepared_reason_multiple_faces" = "Ensure only one face is in front of camera";
+"amplify_ui_liveness_face_not_prepared_reason_face_too_close" = "Move face farther away";
+

--- a/Sources/FaceLiveness/Utilities/LivenessLocalizedStrings.swift
+++ b/Sources/FaceLiveness/Utilities/LivenessLocalizedStrings.swift
@@ -88,4 +88,34 @@ enum LocalizedStrings {
     
     /// en = "You may have to go into settings to grant camera permissions and close the app and retry"
     static let camera_permission_change_setting_description = "amplify_ui_liveness_camera_permission_button_description".localized()
+    
+    /// en = ""
+    static let amplify_ui_liveness_face_not_prepared_reason_pendingCheck = "amplify_ui_liveness_face_not_prepared_reason_pendingCheck".localized()
+    
+    /// en = "Move face to fit in oval"
+    static let amplify_ui_liveness_face_not_prepared_reason_not_in_oval = "amplify_ui_liveness_face_not_prepared_reason_not_in_oval".localized()
+    
+    /// en = "Move closer"
+    static let amplify_ui_liveness_face_not_prepared_reason_move_face_closer = "amplify_ui_liveness_face_not_prepared_reason_move_face_closer".localized()
+    
+    /// en = "Move face right"
+    static let amplify_ui_liveness_face_not_prepared_reason_move_face_right = "amplify_ui_liveness_face_not_prepared_reason_move_face_right".localized()
+    
+    /// en = "Move face left"
+    static let amplify_ui_liveness_face_not_prepared_reason_move_face_left = "amplify_ui_liveness_face_not_prepared_reason_move_face_left".localized()
+    
+    /// en = "Move to dimmer area"
+    static let amplify_ui_liveness_face_not_prepared_reason_move_to_dimmer_area = "amplify_ui_liveness_face_not_prepared_reason_move_to_dimmer_area".localized()
+    
+    /// en = "Move to brighter area"
+    static let amplify_ui_liveness_face_not_prepared_reason_move_to_brighter_area = "amplify_ui_liveness_face_not_prepared_reason_move_to_brighter_area".localized()
+    
+    /// en = "Move face in front of camera"
+    static let amplify_ui_liveness_face_not_prepared_reason_no_face = "amplify_ui_liveness_face_not_prepared_reason_no_face".localized()
+    
+    /// en = "Ensure only one face is in front of camera"
+    static let amplify_ui_liveness_face_not_prepared_reason_multiple_faces = "amplify_ui_liveness_face_not_prepared_reason_multiple_faces".localized()
+    
+    /// en = "Move face farther away"
+    static let amplify_ui_liveness_face_not_prepared_reason_face_too_close = "amplify_ui_liveness_face_not_prepared_reason_face_too_close".localized()
 }

--- a/Sources/FaceLiveness/Views/Instruction/InstructionContainerView.swift
+++ b/Sources/FaceLiveness/Views/Instruction/InstructionContainerView.swift
@@ -43,7 +43,7 @@ struct InstructionContainerView: View {
 
         case .awaitingFaceInOvalMatch(let reason, let percentage):
             InstructionView(
-                text: .init(reason.rawValue),
+                text: .init(reason.localizedValue),
                 backgroundColor: .livenessPrimaryBackground,
                 textColor: .livenessPrimaryLabel,
                 font: .title
@@ -81,7 +81,7 @@ struct InstructionContainerView: View {
             .frame(width: 200, height: 30)
         case .pendingFacePreparedConfirmation(let reason):
             InstructionView(
-                text: .init(reason.rawValue),
+                text: .init(reason.localizedValue),
                 backgroundColor: .livenessPrimaryBackground,
                 textColor: .livenessPrimaryLabel,
                 font: .title

--- a/Sources/FaceLiveness/Views/Liveness/LivenessStateMachine.swift
+++ b/Sources/FaceLiveness/Views/Liveness/LivenessStateMachine.swift
@@ -109,17 +109,42 @@ struct LivenessStateMachine {
         case waitForRecording
     }
 
-    enum FaceNotPreparedReason: String, Equatable {
-        case pendingCheck = ""
-        case notInOval = "Move face to fit in oval"
-        case moveFaceCloser = "Move closer"
-        case moveFaceRight = "Move face right"
-        case moveFaceLeft = "Move face left"
-        case moveToDimmerArea = "Move to dimmer area"
-        case moveToBrighterArea = "Move to brighter area"
-        case noFace = "Move face in front of camera"
-        case multipleFaces = "Ensure only one face is in front of camera"
-        case faceTooClose = "Move face farther away"
+    enum FaceNotPreparedReason {
+        case pendingCheck
+        case notInOval
+        case moveFaceCloser
+        case moveFaceRight
+        case moveFaceLeft
+        case moveToDimmerArea
+        case moveToBrighterArea
+        case noFace
+        case multipleFaces
+        case faceTooClose
+        
+        var localizedValue: String {
+            switch self {
+            case .pendingCheck:
+                return LocalizedStrings.amplify_ui_liveness_face_not_prepared_reason_pendingCheck
+            case .notInOval:
+                return LocalizedStrings.amplify_ui_liveness_face_not_prepared_reason_not_in_oval
+            case .moveFaceCloser:
+                return LocalizedStrings.amplify_ui_liveness_face_not_prepared_reason_move_face_closer
+            case .moveFaceRight:
+                return LocalizedStrings.amplify_ui_liveness_face_not_prepared_reason_move_face_right
+            case .moveFaceLeft:
+                return LocalizedStrings.amplify_ui_liveness_face_not_prepared_reason_move_face_left
+            case .moveToDimmerArea:
+                return LocalizedStrings.amplify_ui_liveness_face_not_prepared_reason_move_to_dimmer_area
+            case .moveToBrighterArea:
+                return LocalizedStrings.amplify_ui_liveness_face_not_prepared_reason_move_to_brighter_area
+            case .noFace:
+                return LocalizedStrings.amplify_ui_liveness_face_not_prepared_reason_no_face
+            case .multipleFaces:
+                return LocalizedStrings.challenge_instruction_multiple_faces_detected
+            case .faceTooClose:
+                return LocalizedStrings.amplify_ui_liveness_face_not_prepared_reason_face_too_close
+            }
+        }
     }
 
     struct LivenessError: Error, Equatable {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-ui-swift-liveness/issues/76

*Description of changes:*
* Add localization string for `FaceNotPreparedReason` string values

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] If breaking change, documentation/changelog update with migration instructions


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
