### PR TITLE
fix: send the final video event at a delayed time interval

### DIFF
--- a/Sources/FaceLiveness/AV/VideoChunker.swift
+++ b/Sources/FaceLiveness/AV/VideoChunker.swift
@@ -56,15 +56,13 @@ final class VideoChunker {
         }
 
         guard state == .writing else { return }
-        let timestamp = CMSampleBufferGetPresentationTimeStamp(buffer).seconds
-
-        if startTimeSeconds == nil { startTimeSeconds = timestamp }
-        guard let startTimeSeconds else {
-            return
-        }
 
         if assetWriterInput.isReadyForMoreMediaData {
             let timestamp = CMSampleBufferGetPresentationTimeStamp(buffer).seconds
+            if startTimeSeconds == nil { startTimeSeconds = timestamp }
+            guard let startTimeSeconds else {
+                return
+            }
             let presentationTime = CMTime(seconds: timestamp - startTimeSeconds, preferredTimescale: 600)
             guard let imageBuffer = buffer.imageBuffer else { return }
 

--- a/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionViewModel+VideoSegmentProcessor.swift
+++ b/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionViewModel+VideoSegmentProcessor.swift
@@ -13,7 +13,9 @@ extension FaceLivenessDetectionViewModel: VideoSegmentProcessor {
         sendVideoEvent(data: chunk, videoEventTime: .zero)
         if !hasSentFinalVideoEvent,
            case .completedDisplayingFreshness = livenessState.state {
-            sendFinalVideoChunk(data: chunk, videoEventTime: .zero)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.9) {
+                self.sendFinalVideoEvent()
+            }
         }
     }
 }

--- a/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionViewModel+VideoSegmentProcessor.swift
+++ b/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionViewModel+VideoSegmentProcessor.swift
@@ -13,7 +13,7 @@ extension FaceLivenessDetectionViewModel: VideoSegmentProcessor {
         sendVideoEvent(data: chunk, videoEventTime: .zero)
         if !hasSentFinalVideoEvent,
            case .completedDisplayingFreshness = livenessState.state {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.9) {
+            DispatchQueue.global(qos: .default).asyncAfter(deadline: .now() + 0.9) {
                 self.sendFinalVideoEvent()
             }
         }

--- a/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionViewModel.swift
+++ b/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionViewModel.swift
@@ -289,27 +289,7 @@ class FaceLivenessDetectionViewModel: ObservableObject {
         }
     }
 
-    func sendVideoEvent(data: Data, videoEventTime: UInt64, n: UInt8 = 1) {
-        guard !hasSentFinalVideoEvent else { return }
-        let eventDate = Date()
-        let timestamp = eventDate.timestampMilliseconds
-
-        let videoEvent = VideoEvent.init(chunk: data, timestamp: timestamp)
-
-        do {
-            try livenessService?.send(
-                .video(event: videoEvent),
-                eventDate: { eventDate }
-            )
-        } catch {
-            DispatchQueue.main.async {
-                self.livenessState.unrecoverableStateEncountered(.unknown)
-            }
-        }
-    }
-
-    func sendFinalVideoChunk(data: Data, videoEventTime: UInt64) {
-        sendVideoEvent(data: data, videoEventTime: videoEventTime)
+    func sendFinalVideoEvent() {
         sendFinalEvent(
             targetFaceRect: faceGuideRect,
             viewSize: videoSize,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* update video segment processor to send the final event at a delayed time interval after the video chunk.  Sending the final video event immediately after the video chunk causes the backend service to queue the final event and results in additional processing latency

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] If breaking change, documentation/changelog update with migration instructions


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
