### PR TITLE
fix: resolve race condition when starting AVCaptureSession

### DIFF
--- a/Sources/FaceLiveness/AV/LivenessCaptureSession.swift
+++ b/Sources/FaceLiveness/AV/LivenessCaptureSession.swift
@@ -11,8 +11,12 @@ import AVFoundation
 class LivenessCaptureSession {
     let captureDevice: LivenessCaptureDevice
     private let captureQueue = DispatchQueue(label: "com.amazonaws.faceliveness.cameracapturequeue")
+    private let configurationQueue = DispatchQueue(label: "com.amazonaws.faceliveness.sessionconfiguration", qos: .userInitiated)
     let outputDelegate: AVCaptureVideoDataOutputSampleBufferDelegate
     var captureSession: AVCaptureSession?
+    private var deviceInput: AVCaptureDeviceInput?
+    private var videoOutput: AVCaptureVideoDataOutput?
+    private var previewLayer: AVCaptureVideoPreviewLayer?
     
     var outputSampleBufferCapturer: OutputSampleBufferCapturer? {
         return outputDelegate as? OutputSampleBufferCapturer
@@ -34,81 +38,80 @@ class LivenessCaptureSession {
             frame: frame,
             for: captureSession
         )
-
+        self.previewLayer = previewLayer
         return previewLayer
     }
     
     func startSession() throws {
+        teardownCurrentSession()
         guard let camera = captureDevice.avCaptureDevice
         else { throw LivenessCaptureSessionError.cameraUnavailable }
-
-        let cameraInput = try AVCaptureDeviceInput(device: camera)
-
-        teardownExistingSession(input: cameraInput)
         captureSession = AVCaptureSession()
+        deviceInput = try AVCaptureDeviceInput(device: camera)
+        videoOutput = AVCaptureVideoDataOutput()
 
         guard let captureSession = captureSession else {
             throw LivenessCaptureSessionError.captureSessionUnavailable
         }
-
-        try setupInput(cameraInput, for: captureSession)
-        captureSession.sessionPreset = captureDevice.preset
-
-        let videoOutput = AVCaptureVideoDataOutput()
-        try setupOutput(videoOutput, for: captureSession)
-
+        guard let input = deviceInput, captureSession.canAddInput(input) else {
+            throw LivenessCaptureSessionError.captureSessionInputUnavailable
+        }
+        guard let output = videoOutput, captureSession.canAddOutput(output) else {
+            throw LivenessCaptureSessionError.captureSessionOutputUnavailable
+        }
         try captureDevice.configure()
-
-        DispatchQueue.global().async {
+        
+        configureOutput(output)
+        
+        configurationQueue.async {
+            captureSession.beginConfiguration()
+            captureSession.sessionPreset = self.captureDevice.preset
+            captureSession.addInput(input)
+            captureSession.addOutput(output)
+            captureSession.commitConfiguration()
             captureSession.startRunning()
         }
+    }
 
-        videoOutput.setSampleBufferDelegate(
+    func stopRunning() {
+        teardownCurrentSession()
+    }
+    
+    private func configureOutput(_ output: AVCaptureVideoDataOutput) {
+        output.videoSettings = [
+            kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA
+        ]
+        
+        output.connections
+            .filter(\.isVideoOrientationSupported)
+            .forEach {
+                $0.videoOrientation = .portrait
+            }
+        
+        output.setSampleBufferDelegate(
             outputDelegate,
             queue: captureQueue
         )
     }
 
-    func stopRunning() {
+    private func teardownCurrentSession() {
         if captureSession?.isRunning == true {
             captureSession?.stopRunning()
         }
-    }
-
-    private func teardownExistingSession(input: AVCaptureDeviceInput) {
-        stopRunning()
-        captureSession?.removeInput(input)
-    }
-
-    private func setupInput(
-        _ input: AVCaptureDeviceInput,
-        for captureSession: AVCaptureSession
-    ) throws {
-        if captureSession.canAddInput(input) {
-            captureSession.addInput(input)
-        } else {
-            throw LivenessCaptureSessionError.captureSessionInputUnavailable
+        
+        if let output = videoOutput {
+            captureSession?.removeOutput(output)
+            videoOutput = nil
         }
-    }
-
-    private func setupOutput(
-        _ output: AVCaptureVideoDataOutput,
-        for captureSession: AVCaptureSession
-    ) throws {
-        if captureSession.canAddOutput(output) {
-            captureSession.addOutput(output)
-        } else {
-            throw LivenessCaptureSessionError.captureSessionOutputUnavailable
+        if let input = deviceInput {
+            captureSession?.removeInput(input)
+            deviceInput = nil
         }
-        output.videoSettings = [
-            kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA
-        ]
-
-        output.connections
-            .filter(\.isVideoOrientationSupported)
-            .forEach {
-                $0.videoOrientation = .portrait
-        }
+    
+        previewLayer?.removeFromSuperlayer()
+        previewLayer?.session = nil
+        previewLayer = nil
+        captureSession = nil
     }
 
     private func previewLayer(

--- a/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionView.swift
+++ b/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionView.swift
@@ -172,6 +172,9 @@ public struct FaceLivenessDetectorView: View {
                     UIScreen.main.brightness = 1.0
                 }
             }
+            .onDisappear() {
+                viewModel.stopRecording()
+            }
             .onReceive(viewModel.$livenessState) { output in
                 switch output.state {
                 case .completed:

--- a/Sources/FaceLiveness/Views/Liveness/LivenessViewController.swift
+++ b/Sources/FaceLiveness/Views/Liveness/LivenessViewController.swift
@@ -37,6 +37,12 @@ final class _LivenessViewController: UIViewController {
             }
         }
     }
+    
+    deinit {
+        self.previewLayer.removeFromSuperlayer()
+        (self.previewLayer as? AVCaptureVideoPreviewLayer)?.session = nil
+        self.previewLayer = nil
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -110,6 +116,7 @@ extension _LivenessViewController: FaceLivenessViewControllerPresenter {
             imageView.frame = self.previewLayer.frame
             self.view.addSubview(imageView)
             self.previewLayer.removeFromSuperlayer()
+            (self.previewLayer as? AVCaptureVideoPreviewLayer)?.session = nil
             self.viewModel.stopRecording()
         }
     }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-ui-swift-liveness/issues/68
*Description of changes:*
Root cause: 

If the liveness check screen and open and dismissed quickly several times, it's possible to run into a race condition wherein the `AVCaptureSession.startRunning()` while it is being configured which results in the following error
```
'NSGenericException', reason: '*** -[AVCaptureSession startRunning] startRunning may not be called between calls to beginConfiguration and commitConfiguration'
```

Resolution: 
* Start the AVCaptureSession in a queue that has a higher QoS
* Add additional code to cleanup and dispose of the AVCaptureVideoPreviewLayer and its associate AVCaptureSession
* In Flutter app, depending on the integration, it's possible to dismiss the Liveness Check screen by swiping away the view if the integration doesn't support fullscreen mode; add code to stop recording if the view disappears.

The requester of the issue was able to test and verify the fix with their Flutter app.

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] If breaking change, documentation/changelog update with migration instructions


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
