### PR TITLE
fix: cleanup camera session in the preview page

### DIFF
--- a/Sources/FaceLiveness/AV/LivenessCaptureSession.swift
+++ b/Sources/FaceLiveness/AV/LivenessCaptureSession.swift
@@ -69,18 +69,23 @@ class LivenessCaptureSession {
     }
 
     func stopRunning() {
-        if captureSession?.isRunning == true {
-            captureSession?.stopRunning()
+        guard let session = captureSession else { return }
+
+        defer {
+            captureSession = nil
         }
-        if let session = captureSession {
-            for input in session.inputs {
-                session.removeInput(input)
-            }
-            for output in session.outputs {
-                session.removeOutput(output)
-            }
+
+        if session.isRunning {
+            session.stopRunning()
         }
-        captureSession = nil
+
+        for input in session.inputs {
+            session.removeInput(input)
+        }
+        
+        for output in session.outputs {
+            session.removeOutput(output)
+        }
     }
 
     private func teardownExistingSession(input: AVCaptureDeviceInput) {

--- a/Sources/FaceLiveness/AV/LivenessCaptureSession.swift
+++ b/Sources/FaceLiveness/AV/LivenessCaptureSession.swift
@@ -72,6 +72,15 @@ class LivenessCaptureSession {
         if captureSession?.isRunning == true {
             captureSession?.stopRunning()
         }
+        if let session = captureSession {
+            for input in session.inputs {
+                session.removeInput(input)
+            }
+            for output in session.outputs {
+                session.removeOutput(output)
+            }
+        }
+        captureSession = nil
     }
 
     private func teardownExistingSession(input: AVCaptureDeviceInput) {

--- a/Sources/FaceLiveness/Views/GetReadyPage/CameraPreviewView.swift
+++ b/Sources/FaceLiveness/Views/GetReadyPage/CameraPreviewView.swift
@@ -39,6 +39,8 @@ struct CameraPreviewView: View {
                     .position(x: geometry.size.width*Self.previewXPositionRatio,
                               y: geometry.size.height*Self.previewYPositionRatio)
             }
+        }.onDisappear {
+            model.stopSession()
         }
     }
 }

--- a/Sources/FaceLiveness/Views/GetReadyPage/CameraPreviewViewModel.swift
+++ b/Sources/FaceLiveness/Views/GetReadyPage/CameraPreviewViewModel.swift
@@ -33,7 +33,7 @@ class CameraPreviewViewModel: NSObject, ObservableObject {
         )
         
         do {
-            try self.previewCaptureSession?.startSession()
+            try previewCaptureSession?.startSession()
         } catch {
             Amplify.Logging.default.error("Error starting preview capture session with error: \(error)")
         }
@@ -46,6 +46,10 @@ class CameraPreviewViewModel: NSObject, ObservableObject {
                 return CGImage.convert(from: $0)
             }
             .assign(to: &$currentImageFrame)
+    }
+
+    func stopSession() {
+        previewCaptureSession?.stopRunning()
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-ui-swift-liveness/issues/98
*Description of changes:*
* Make sure to stop the camera session in the preview screen so that the camera session doesn't continue to run

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
