### PR TITLE
fix: ensure video image is mirrored

### DIFF
--- a/Sources/FaceLiveness/AV/LivenessCaptureSession.swift
+++ b/Sources/FaceLiveness/AV/LivenessCaptureSession.swift
@@ -121,6 +121,7 @@ class LivenessCaptureSession {
             .filter(\.isVideoOrientationSupported)
             .forEach {
                 $0.videoOrientation = .portrait
+                $0.isVideoMirrored = true
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-ui-swift-liveness/issues/103
*Description of changes:*
* Ensure that the video setting for the AVCaptureSession is mirrored.  There was previous code that manually rotated and mirrored the images and was removed in favor of setting the video session to be portrait.  This [code](https://github.com/aws-amplify/amplify-ui-swift-liveness/pull/91) change missed setting it video output to mirror.

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
