### PR TITLE
fix: add additional guard for finishing AVAssetWriter

### DIFF
--- a/Sources/FaceLiveness/AV/VideoChunker.swift
+++ b/Sources/FaceLiveness/AV/VideoChunker.swift
@@ -44,7 +44,9 @@ final class VideoChunker {
         state = .awaitingSingleFrame
 
         // explicitly calling `endSession` is unnecessary
-        assetWriter.finishWriting {}
+        if state != .complete {
+            assetWriter.finishWriting {}
+        }
     }
 
     func consume(_ buffer: CMSampleBuffer) {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-ui-swift-liveness/issues/99
*Description of changes:*
* Prevent crash in `AVAssetWriter.finishWriting` if the AVAssetWriter has already finished
* Tested manually to verify the method is not called once the state is completed.

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
