### PR TITLE
fix: prevent AVCaptureSession from starting during session configuration

### DIFF
--- a/Sources/FaceLiveness/AV/LivenessCaptureSession.swift
+++ b/Sources/FaceLiveness/AV/LivenessCaptureSession.swift
@@ -73,7 +73,6 @@ class LivenessCaptureSession {
 
     func stopRunning() {
         guard let session = captureSession else { return }
-        print("*** Stop running")
         defer {
             captureSession = nil
         }

--- a/Sources/FaceLiveness/AV/LivenessCaptureSession.swift
+++ b/Sources/FaceLiveness/AV/LivenessCaptureSession.swift
@@ -24,8 +24,8 @@ class LivenessCaptureSession {
         self.outputDelegate = outputDelegate
     }
 
-    func startSession(frame: CGRect) throws -> CALayer {
-        try startSession()
+    func configureCamera(frame: CGRect) throws -> CALayer {
+        try configureCamera()
 
         guard let captureSession = captureSession else {
             throw LivenessCaptureSessionError.captureSessionUnavailable
@@ -39,7 +39,7 @@ class LivenessCaptureSession {
         return previewLayer
     }
     
-    func startSession() throws {
+    func configureCamera() throws {
         guard let camera = captureDevice.avCaptureDevice
         else { throw LivenessCaptureSessionError.cameraUnavailable }
 
@@ -58,19 +58,22 @@ class LivenessCaptureSession {
         try setupOutput(videoOutput, for: captureSession)
         try captureDevice.configure()
 
-        configurationQueue.async {
-            captureSession.startRunning()
-        }
-
         videoOutput.setSampleBufferDelegate(
             outputDelegate,
             queue: captureQueue
         )
     }
 
+    func startSession() {
+        guard let session = captureSession else { return }
+        configurationQueue.async {
+            session.startRunning()
+        }
+    }
+
     func stopRunning() {
         guard let session = captureSession else { return }
-
+        print("*** Stop running")
         defer {
             captureSession = nil
         }

--- a/Sources/FaceLiveness/Views/GetReadyPage/CameraPreviewViewModel.swift
+++ b/Sources/FaceLiveness/Views/GetReadyPage/CameraPreviewViewModel.swift
@@ -33,7 +33,8 @@ class CameraPreviewViewModel: NSObject, ObservableObject {
         )
         
         do {
-            try previewCaptureSession?.startSession()
+            try previewCaptureSession?.configureCamera()
+            previewCaptureSession?.startSession()
         } catch {
             Amplify.Logging.default.error("Error starting preview capture session with error: \(error)")
         }

--- a/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionViewModel.swift
+++ b/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionViewModel.swift
@@ -122,14 +122,17 @@ class FaceLivenessDetectionViewModel: ObservableObject {
         }
     }
 
+    func startSession() {
+        captureSession.startSession()
+    }
 
     func stopRecording() {
         captureSession.stopRunning()
     }
 
-    func startCamera(withinFrame frame: CGRect) -> CALayer? {
+    func configureCamera(withinFrame frame: CGRect) -> CALayer? {
         do {
-            let avLayer = try captureSession.startSession(frame: frame)
+            let avLayer = try captureSession.configureCamera(frame: frame)
             DispatchQueue.main.async {
                 self.livenessState.checkIsFacePrepared()
             }

--- a/Sources/FaceLiveness/Views/Liveness/LivenessViewController.swift
+++ b/Sources/FaceLiveness/Views/Liveness/LivenessViewController.swift
@@ -49,9 +49,6 @@ final class _LivenessViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .black
         layoutSubviews()
-    }
-
-    override func viewDidAppear(_ animated: Bool) {
         setupAVLayer()
     }
 
@@ -69,13 +66,14 @@ final class _LivenessViewController: UIViewController {
     }
 
     private func setupAVLayer() {
+        guard previewLayer == nil else { return }
         let x = view.frame.minX
         let y = view.frame.minY
         let width = view.frame.width
         let height = width / 3 * 4
         let cameraFrame = CGRect(x: x, y: y, width: width, height: height)
 
-        guard let avLayer = viewModel.startCamera(withinFrame: cameraFrame) else {
+        guard let avLayer = viewModel.configureCamera(withinFrame: cameraFrame) else {
             DispatchQueue.main.async {
                 self.viewModel.livenessState
                     .unrecoverableStateEncountered(.missingVideoPermission)
@@ -92,6 +90,8 @@ final class _LivenessViewController: UIViewController {
         DispatchQueue.main.async {
             self.view.layer.insertSublayer(avLayer, at: 0)
             self.view.layoutIfNeeded()
+
+            self.viewModel.startSession()
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Update the logic for configuring and starting the AVCaptureSession so that starting the session is deferred after the session is configured to avoid AVCaptureSession crash as a result of in progress configuration of session.

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
