### PR TITLE
fix: remove strong reference retain cycle from camera preview view model

### DIFF
--- a/Sources/FaceLiveness/Views/GetReadyPage/CameraPreviewOutputSampleBufferDelegate.swift
+++ b/Sources/FaceLiveness/Views/GetReadyPage/CameraPreviewOutputSampleBufferDelegate.swift
@@ -1,0 +1,28 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import AVFoundation
+import CoreImage
+
+class CameraPreviewOutputSampleBufferDelegate: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate {
+
+    let updateBufferHandler: ((CVImageBuffer) -> Void)
+
+    init(_ updateBufferHandler: @escaping (CVImageBuffer) -> Void) {
+        self.updateBufferHandler = updateBufferHandler
+    }
+
+    func captureOutput(
+        _ output: AVCaptureOutput,
+        didOutput sampleBuffer: CMSampleBuffer,
+        from connection: AVCaptureConnection
+    ) {
+        if let buffer = sampleBuffer.imageBuffer {
+            updateBufferHandler(buffer)
+        }
+    }
+}

--- a/Sources/FaceLiveness/Views/GetReadyPage/CameraPreviewViewModel.swift
+++ b/Sources/FaceLiveness/Views/GetReadyPage/CameraPreviewViewModel.swift
@@ -27,9 +27,13 @@ class CameraPreviewViewModel: NSObject, ObservableObject {
             position: .front
         ).devices.first
 
+        let outputDelegate = CameraPreviewOutputSampleBufferDelegate { [weak self] buffer in
+            self?.updateBuffer(buffer)
+        }
+
         self.previewCaptureSession = LivenessCaptureSession(
             captureDevice: .init(avCaptureDevice: avCaptureDevice),
-            outputDelegate: self
+            outputDelegate: outputDelegate
         )
         
         do {
@@ -52,18 +56,10 @@ class CameraPreviewViewModel: NSObject, ObservableObject {
     func stopSession() {
         previewCaptureSession?.stopRunning()
     }
-}
 
-extension CameraPreviewViewModel: AVCaptureVideoDataOutputSampleBufferDelegate {
-    func captureOutput(
-        _ output: AVCaptureOutput,
-        didOutput sampleBuffer: CMSampleBuffer,
-        from connection: AVCaptureConnection
-    ) {
-        if let buffer = sampleBuffer.imageBuffer {
-            DispatchQueue.main.async {
-                self.buffer = buffer
-            }
+    func updateBuffer(_ buffer: CVImageBuffer) {
+        DispatchQueue.main.async {
+            self.buffer = buffer
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-ui-swift-liveness/issues/129

*Description of changes:*
* Refactor and remove strong reference retain cycle between `CameraPreviewViewModel` and `LivenessCaptureSession`
* Tested and verified that strong reference doesn't exists when viewed in Xcode's memory graph

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
