### PR TITLE
chore: update ruby version to fix CI deployments

### DIFF
--- a/.github/workflows/deploy_liveness.yml
+++ b/.github/workflows/deploy_liveness.yml
@@ -67,7 +67,7 @@ jobs:
           token: ${{steps.retrieve-token.outputs.token}}
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@250fcd6a742febb1123a77a841497ccaa8b9e939 # v1.152.0
+        uses: ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7 # v1.171.0
         with:
           ruby-version: '3.2.1'
           bundler-cache: true


### PR DESCRIPTION
*Issue #, if available:*
Unstable release GH action failing: https://github.com/aws-amplify/amplify-ui-swift-liveness/actions/runs/8974137653

*Description of changes:*
Update ruby version to `1.171.0`

*Check points: (check or cross out if not relevant)*

~~- [ ] Added new tests to cover change, if needed~~
~~- [ ] Build succeeds with all target using Swift Package Manager~~
~~- [ ] All unit tests pass~~
~~- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)~~
~~- [ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
~~- [ ] If breaking change, documentation/changelog update with migration instructions~~


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
