### PR TITLE
fix: Fixing video not being mirrored in the 'Get Ready' screen

### DIFF
--- a/Sources/FaceLiveness/Views/GetReadyPage/ImageFrameView.swift
+++ b/Sources/FaceLiveness/Views/GetReadyPage/ImageFrameView.swift
@@ -13,7 +13,7 @@ struct ImageFrameView: View {
     var body: some View {
         if let image = image {
             GeometryReader { geometry in
-                Image(decorative: image, scale: 1.0, orientation: .upMirrored)
+                Image(decorative: image, scale: 1.0, orientation: .up)
                     .resizable()
                     .scaledToFill()
                     .frame(


### PR DESCRIPTION
**Description of changes:**

This PR fixes the video feed not being mirrored in the "Get Ready" view. This was happening because the video **was** mirrored, but the Image displayed on this screen was being mirrored **again**.

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
