### PR TITLE
fix: Updating the camera frame position when the subviews are laid out

### DIFF
--- a/HostApp/HostApp.xcodeproj/project.pbxproj
+++ b/HostApp/HostApp.xcodeproj/project.pbxproj
@@ -34,7 +34,6 @@
 		97D1A8E92BA3757700FF1368 /* AWSAPIPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 97D1A8E82BA3757700FF1368 /* AWSAPIPlugin */; };
 		97D1A8EB2BA3757700FF1368 /* AWSCognitoAuthPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 97D1A8EA2BA3757700FF1368 /* AWSCognitoAuthPlugin */; };
 		97D1A8ED2BA3757700FF1368 /* Amplify in Frameworks */ = {isa = PBXBuildFile; productRef = 97D1A8EC2BA3757700FF1368 /* Amplify */; };
-		97D1A8EF2BA375AA00FF1368 /* amplify-ui-swift-liveness in Resources */ = {isa = PBXBuildFile; fileRef = 97D1A8EE2BA375AA00FF1368 /* amplify-ui-swift-liveness */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -308,8 +307,6 @@
 				Base,
 			);
 			mainGroup = 9070FF97285112B4009867D5;
-			packageReferences = (
-			);
 			productRefGroup = 9070FFA1285112B4009867D5 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -328,7 +325,6 @@
 			files = (
 				973619262BA378690003A590 /* awsconfiguration.json in Resources */,
 				9070FFAB285112B5009867D5 /* Preview Assets.xcassets in Resources */,
-				97D1A8EF2BA375AA00FF1368 /* amplify-ui-swift-liveness in Resources */,
 				9070FFA8285112B5009867D5 /* Assets.xcassets in Resources */,
 				973619252BA378690003A590 /* amplifyconfiguration.json in Resources */,
 			);

--- a/Sources/FaceLiveness/Views/Liveness/LivenessViewController.swift
+++ b/Sources/FaceLiveness/Views/Liveness/LivenessViewController.swift
@@ -49,7 +49,11 @@ final class _LivenessViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .black
         layoutSubviews()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
         setupAVLayer()
+        super.viewWillAppear(animated)
     }
 
     private func layoutSubviews() {

--- a/Sources/FaceLiveness/Views/Liveness/LivenessViewController.swift
+++ b/Sources/FaceLiveness/Views/Liveness/LivenessViewController.swift
@@ -49,11 +49,11 @@ final class _LivenessViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .black
         layoutSubviews()
+        setupAVLayer()
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        setupAVLayer()
-        super.viewWillAppear(animated)
+    override func viewDidLayoutSubviews() {
+        previewLayer?.position = view.center
     }
 
     private func layoutSubviews() {


### PR DESCRIPTION
**Description of changes:**

The `_LivenessViewController` currently centers its camera frame only when its view is loaded, but not when its subviews are laid out. 
This causes the video feed to appear off-centered when the `FaceLivenessDetectorView` is stacked with other components (i.e. headers, navigation bars, etc), or when used in a `UIHostingController`.

This PR fixes this issue by re-centering the camera frame on `viewDidLayoutSubviews()`. 

---
I'm also removing the liveness package being unnecessary copied as a resource for the example HostApp

---

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
