### PR TITLE
fix: Fixing a crash when attempting to call finishWriting

### DIFF
--- a/Sources/FaceLiveness/AV/VideoChunker.swift
+++ b/Sources/FaceLiveness/AV/VideoChunker.swift
@@ -44,7 +44,7 @@ final class VideoChunker {
         state = .awaitingSingleFrame
 
         // explicitly calling `endSession` is unnecessary
-        if state != .complete {
+        if assetWriter.status != .completed {
             assetWriter.finishWriting {}
         }
     }


### PR DESCRIPTION
**Issue #, if available:**
- https://github.com/aws-amplify/amplify-ui-swift-liveness/issues/148

**Description of changes:**

This PR attempts to fix an `NSInternalInconsistencyException` crash that might be happening when calling `AVAssetWriter.finishWriting` on an instance that is already `completed`.

There was a previous validation in place that checked if `state != .complete`, but `state` is a local variable that is not really tracking the write's state, so I decided to replace it with `AVAssetWriter.status`.

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
