### PR TITLE
feat(FaceLivenessDetectionError): Adding new `.cameraNotAvailable` error.

### DIFF
--- a/HostApp/HostApp/Views/ExampleLivenessView.swift
+++ b/HostApp/HostApp/Views/ExampleLivenessView.swift
@@ -45,6 +45,8 @@ struct ExampleLivenessView: View {
                         viewModel.presentationState = .error(.countdownFaceTooClose)
                     case .failure(.invalidSignature):
                         viewModel.presentationState = .error(.invalidSignature)
+                    case .failure(.cameraNotAvailable):
+                        viewModel.presentationState = .error(.cameraNotAvailable)
                     default:
                         viewModel.presentationState = .liveness
                     }
@@ -74,6 +76,8 @@ struct ExampleLivenessView: View {
                         LivenessCheckErrorContentView.failedDuringCountdown
                     case .invalidSignature:
                         LivenessCheckErrorContentView.invalidSignature
+                    case .cameraNotAvailable:
+                        LivenessCheckErrorContentView.cameraNotAvailable
                     default:
                         LivenessCheckErrorContentView.unexpected
                     }

--- a/HostApp/HostApp/Views/LivenessCheckErrorContentView.swift
+++ b/HostApp/HostApp/Views/LivenessCheckErrorContentView.swift
@@ -55,6 +55,11 @@ extension LivenessCheckErrorContentView {
         name: "The signature on the request is invalid.",
         description: "Ensure the device time is correct and try again."
     )
+
+    static let cameraNotAvailable = LivenessCheckErrorContentView(
+        name: "The camera could not be started.",
+        description: "There might be a hardware issue with the camera."
+    )
 }
 
 struct LivenessCheckErrorContentView_Previews: PreviewProvider {

--- a/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionError.swift
+++ b/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionError.swift
@@ -126,6 +126,12 @@ public struct FaceLivenessDetectionError: Error, Equatable {
         recoverySuggestion: "Ensure the device time is correct and try again."
     )
 
+    public static let cameraNotAvailable = FaceLivenessDetectionError(
+        code: 18,
+        message: "The camera is not available.",
+        recoverySuggestion: "There might be a hardware issue."
+    )
+
     public static func == (lhs: FaceLivenessDetectionError, rhs: FaceLivenessDetectionError) -> Bool {
         lhs.code == rhs.code
     }

--- a/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionView.swift
+++ b/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionView.swift
@@ -205,6 +205,8 @@ public struct FaceLivenessDetectorView: View {
             return .faceInOvalMatchExceededTimeLimitError
         case .socketClosed:
             return .socketClosed
+        case .cameraNotAvailable:
+            return .cameraNotAvailable
         default:
             return .cameraPermissionDenied
         }

--- a/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionViewModel.swift
+++ b/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionViewModel.swift
@@ -338,8 +338,8 @@ class FaceLivenessDetectionViewModel: ObservableObject {
         switch captureSessionError {
         case LivenessCaptureSessionError.cameraUnavailable,
             LivenessCaptureSessionError.deviceInputUnavailable:
-
-            livenessError = .missingVideoPermission
+            let authStatus = AVCaptureDevice.authorizationStatus(for: .video)
+            livenessError = authStatus == .authorized ? .cameraNotAvailable : .missingVideoPermission
         case LivenessCaptureSessionError.captureSessionOutputUnavailable,
             LivenessCaptureSessionError.captureSessionInputUnavailable:
 

--- a/Sources/FaceLiveness/Views/Liveness/LivenessStateMachine.swift
+++ b/Sources/FaceLiveness/Views/Liveness/LivenessStateMachine.swift
@@ -159,6 +159,7 @@ struct LivenessStateMachine {
         static let couldNotOpenStream = LivenessError(code: 5, webSocketCloseCode: .unexpectedRuntimeError)
         static let socketClosed = LivenessError(code: 6, webSocketCloseCode: .normalClosure)
         static let viewResignation = LivenessError(code: 8, webSocketCloseCode: .viewClosure)
+        static let cameraNotAvailable = LivenessError(code: 9, webSocketCloseCode: .missingVideoPermission)
 
         static func == (lhs: LivenessError, rhs: LivenessError) -> Bool {
             lhs.code == rhs.code


### PR DESCRIPTION
**Description of changes:**

This PR adds `FaceLivenessDetectionError.cameraNotAvailable`, which is reported when there's a problem accessing the camera that is **not** caused by lack of user permissions.

The underlying websocket close code for this error remains `4006`, as per the contract with the Rekognition service.

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
  -   TBA
- [X] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
