### PR TITLE
fix: Returning .userCancelled when the app goes to the background during a Liveness check.

### DIFF
--- a/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionView.swift
+++ b/Sources/FaceLiveness/Views/Liveness/FaceLivenessDetectionView.swift
@@ -199,7 +199,7 @@ public struct FaceLivenessDetectorView: View {
 
     func mapError(_ livenessError: LivenessStateMachine.LivenessError) -> FaceLivenessDetectionError {
         switch livenessError {
-        case .userCancelled:
+        case .userCancelled, .viewResignation:
             return .userCancelled
         case .timedOut:
             return .faceInOvalMatchExceededTimeLimitError


### PR DESCRIPTION
**Issue #, if available:**
- https://github.com/aws-amplify/amplify-ui-swift-liveness/issues/166

**Description of changes:**
This PR maps the internal `LivenessError.viewResignation` error to the public `FaceLivenessDetectionError.userCancelled`, so that we report that one when the user sends the app to the background during a liveness check.

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
