### PR TITLE
chore: update Amplify dependency to 2.38.0 for clock skew support

### DIFF
--- a/HostApp/HostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/HostApp/HostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/aws-amplify/amplify-swift",
       "state" : {
-        "revision" : "7846328106dba471b3fb35170155e92aad50d427",
-        "version" : "2.33.3"
+        "revision" : "79d062d354bb190666774e8ef3c83ad52f023889",
+        "version" : "2.38.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephencelis/SQLite.swift.git",
       "state" : {
-        "revision" : "e78ae0220e17525a15ac68c697a155eb7a672a8e",
-        "version" : "0.15.0"
+        "revision" : "a95fc6df17d108bd99210db5e8a9bac90fe984b8",
+        "version" : "0.15.3"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
-        "version" : "1.5.4"
+        "revision" : "9cb486020ebf03bfa5b5df985387a14a98744537",
+        "version" : "1.6.1"
       }
     }
   ],

--- a/HostApp/HostApp/Views/ExampleLivenessView.swift
+++ b/HostApp/HostApp/Views/ExampleLivenessView.swift
@@ -23,13 +23,11 @@ struct ExampleLivenessView: View {
             FaceLivenessDetectorView(
                 sessionID: viewModel.sessionID,
                 region: "us-east-1",
-                disableStartView: true,
                 isPresented:  Binding(
                     get: { viewModel.presentationState == .liveness },
                     set: { _ in }
                 ),
                 onCompletion: { result in
-                    print("\(#function) result: \(result)")
                     DispatchQueue.main.async {
                         switch result {
                         case .success:

--- a/HostApp/HostApp/Views/ExampleLivenessView.swift
+++ b/HostApp/HostApp/Views/ExampleLivenessView.swift
@@ -23,32 +23,36 @@ struct ExampleLivenessView: View {
             FaceLivenessDetectorView(
                 sessionID: viewModel.sessionID,
                 region: "us-east-1",
+                disableStartView: true,
                 isPresented:  Binding(
                     get: { viewModel.presentationState == .liveness },
                     set: { _ in }
                 ),
                 onCompletion: { result in
-                    switch result {
-                    case .success:
-                        withAnimation { viewModel.presentationState = .result }
-                    case .failure(.sessionNotFound), .failure(.cameraPermissionDenied), .failure(.accessDenied):
-                        viewModel.presentationState = .liveness
-                        isPresented = false
-                    case .failure(.userCancelled):
-                        viewModel.presentationState = .liveness
-                        isPresented = false
-                    case .failure(.sessionTimedOut):
-                        viewModel.presentationState = .error(.sessionTimedOut)
-                    case .failure(.socketClosed):
-                        viewModel.presentationState = .error(.socketClosed)
-                    case .failure(.countdownNoFace), .failure(.countdownFaceTooClose), .failure(.countdownMultipleFaces):
-                        viewModel.presentationState = .error(.countdownFaceTooClose)
-                    case .failure(.invalidSignature):
-                        viewModel.presentationState = .error(.invalidSignature)
-                    case .failure(.cameraNotAvailable):
-                        viewModel.presentationState = .error(.cameraNotAvailable)
-                    default:
-                        viewModel.presentationState = .liveness
+                    print("\(#function) result: \(result)")
+                    DispatchQueue.main.async {
+                        switch result {
+                        case .success:
+                            withAnimation { viewModel.presentationState = .result }
+                        case .failure(.sessionNotFound), .failure(.cameraPermissionDenied), .failure(.accessDenied):
+                            viewModel.presentationState = .liveness
+                            isPresented = false
+                        case .failure(.userCancelled):
+                            viewModel.presentationState = .liveness
+                            isPresented = false
+                        case .failure(.sessionTimedOut):
+                            viewModel.presentationState = .error(.sessionTimedOut)
+                        case .failure(.socketClosed):
+                            viewModel.presentationState = .error(.socketClosed)
+                        case .failure(.countdownNoFace), .failure(.countdownFaceTooClose), .failure(.countdownMultipleFaces):
+                            viewModel.presentationState = .error(.countdownFaceTooClose)
+                        case .failure(.invalidSignature):
+                            viewModel.presentationState = .error(.invalidSignature)
+                        case .failure(.cameraNotAvailable):
+                            viewModel.presentationState = .error(.cameraNotAvailable)
+                        default:
+                            viewModel.presentationState = .liveness
+                        }
                     }
                 }
             )

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/aws-amplify/amplify-swift",
       "state" : {
-        "revision" : "dbc4a0412f4b5cd96f3e756e78bbd1e8e0a35a2f",
-        "version" : "2.35.4"
+        "revision" : "79d062d354bb190666774e8ef3c83ad52f023889",
+        "version" : "2.38.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["FaceLiveness"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/aws-amplify/amplify-swift", exact: "2.35.4")
+        .package(url: "https://github.com/aws-amplify/amplify-swift", exact: "2.38.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Update `amplify-swift` dependency to 2.38.0 for clock skew support
https://github.com/aws-amplify/amplify-swift/releases/tag/2.38.0

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
