### PR TITLE
chore: Update amplify-swift to 2.53.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/aws-amplify/amplify-swift",
       "state" : {
-        "revision" : "2fe27275101dcb945b9198f16b6285055c1dab5e",
-        "version" : "2.51.5"
+        "revision" : "67be15dc214b0674432a544a683615af792f09a3",
+        "version" : "2.53.2"
       }
     },
     {
@@ -19,12 +19,21 @@
       }
     },
     {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client.git",
+      "state" : {
+        "revision" : "c464bf94eac4273cad7424307a5dc7e44e361905",
+        "version" : "1.30.1"
+      }
+    },
+    {
       "identity" : "aws-crt-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-crt-swift",
       "state" : {
-        "revision" : "5be6550f81c760cceb0a43c30d4149ac55c5640c",
-        "version" : "0.52.1"
+        "revision" : "8241ad06622f7351e8843dfab6bbce14fe6bce5d",
+        "version" : "0.54.2"
       }
     },
     {
@@ -32,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-sdk-swift",
       "state" : {
-        "revision" : "8b5336764297d34157bd580374b5f6e182746759",
-        "version" : "1.5.18"
+        "revision" : "61d0ab5b429599f22c44b71b0737f030dc82f76b",
+        "version" : "1.6.7"
       }
     },
     {
@@ -68,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/smithy-lang/smithy-swift",
       "state" : {
-        "revision" : "a6cac0739d76ef08e2d927febc682d9898e76fe2",
-        "version" : "0.152.0"
+        "revision" : "0f3fb709fd034ad4b7a19567858571d08a5f4cbe",
+        "version" : "0.175.0"
       }
     },
     {
@@ -151,6 +160,15 @@
       "state" : {
         "revision" : "e8ed8867ec23bccf5f3bb9342148fa8deaff9b49",
         "version" : "4.1.0"
+      }
+    },
+    {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "baa932c1336f7894145cbaafcd34ce2dd0b77c97",
+        "version" : "1.3.1"
       }
     },
     {
@@ -250,6 +268,15 @@
       "state" : {
         "revision" : "c169a5744230951031770e27e475ff6eefe51f9d",
         "version" : "1.33.3"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "1983448fefc717a2bc2ebde5490fe99873c5b8a6",
+        "version" : "1.2.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["FaceLiveness"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/aws-amplify/amplify-swift", from: "2.51.5")
+        .package(url: "https://github.com/aws-amplify/amplify-swift", from: "2.53.2")
     ],
     targets: [
         .target(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updates Amplify to resolve a dependabot alert from a transitive dependency.

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
